### PR TITLE
fix: Ensure subAreaCode is submitted for process creation

### DIFF
--- a/packages/igrp-wf-studio-ui/src/components/modals/CreateProcessModal.tsx
+++ b/packages/igrp-wf-studio-ui/src/components/modals/CreateProcessModal.tsx
@@ -94,7 +94,10 @@ const CreateProcessModal: React.FC<CreateProcessProps> = ({
         <form action={formAction} className="p-4 space-y-4">
           <input type="hidden" name="appCode" value={workspaceCode} />
           <input type="hidden" name="areaCode" value={selectedAreaCode} />
-          {/* areaCode e subAreaCode serão passados via select e hidden inputs se necessário, ou a action os infere */}
+          {/* Ensure subAreaCode is submitted if selected, especially when dropdown might be disabled */}
+          {selectedSubAreaCode && (
+            <input type="hidden" name="subAreaCode" value={selectedSubAreaCode} />
+          )}
 
           <div>
             <label htmlFor="areaCode" className="form-label">Area*</label>


### PR DESCRIPTION
When creating a process under a subarea, the subarea select dropdown was disabled. Disabled fields are not submitted with the form, leading to the subAreaCode being null or empty in the server action.

This commit adds a hidden input field for subAreaCode in the CreateProcessModal. This ensures that the selected subAreaCode is always submitted, allowing for correct association of the process with its parent subarea.